### PR TITLE
added support for liquidations in internal transactions

### DIFF
--- a/subgraphs/cauldrons/src/utils/is-liquidate.ts
+++ b/subgraphs/cauldrons/src/utils/is-liquidate.ts
@@ -1,9 +1,50 @@
-import { ethereum } from '@graphprotocol/graph-ts';
+import { Bytes, ethereum, log } from '@graphprotocol/graph-ts';
 
+const LOG_REPAY_TOPIC0 = Bytes.fromHexString('0xc8e512d8f188ca059984b5853d2bf653da902696b8512785b182b2c813789a6e'); // LogRepay(address,address,uint256,uint256)
+const LOG_REMOVE_COLLATERAL_TOPIC0 = Bytes.fromHexString('0x8ad4d3ff00da092c7ad9a573ea4f5f6a3dffc6712dc06d3f78f49b862297c402'); // LogRemoveCollateral(address,address,uint256)
+
+/**
+ * Check if LogRemoveCollateral event or LogRepay event is part of a liquidation.
+ *
+ * Liquidations are identified by a LogRemoveCollateral followed by a LogRepay.
+ * When collateral is removed there is always a LogTransfer event emitted
+ * from the BentoBox after a LogRemoveCollateral event.
+ */
 export function isLiquidate(event: ethereum.Event): boolean {
-    const method = event.transaction.input.toHexString().substr(0, 10);
-    return method == '0x912860c5' || method == '0xff6ff84b';
-}
+    const receipt = event.receipt;
+    if (receipt === null) {
+        log.error('Event must have receipt to check if it is a liquidation', []);
+        return false;
+    }
+    const logs = receipt.logs;
 
-// 0x912860c5 -> liquidate(address[],uint256[],address,address)
-// 0xff6ff84b -> liquidate(address[],uint256[],address,address,bytes)
+    // Find the index in this specific transaction (as opposed to the block)
+    const logIndexInTransaction = event.logIndex.minus(logs[0].logIndex).abs().toI32();
+    const currentLog = logs[logIndexInTransaction];
+
+    if (currentLog.topics.length <= 0) {
+        log.warning('Only LogRepay and LogRemoveCollateral can be a liquidation, but log had no topics. Transaction hash: {}, log index: {}', [
+            event.transaction.hash.toHexString(),
+            logIndexInTransaction.toString(),
+        ]);
+    }
+
+    if (currentLog.topics[0] == LOG_REPAY_TOPIC0) {
+        if (logIndexInTransaction == 0) {
+            return false; // Not a liquidation if LogRepay is first log in the transaction
+        }
+        const topics = logs[logIndexInTransaction - 1].topics;
+        return topics.length > 0 && topics[0] == LOG_REMOVE_COLLATERAL_TOPIC0;
+    } else if (currentLog.topics[0] == LOG_REMOVE_COLLATERAL_TOPIC0) {
+        // Not possible for LogRemoveCollateral to be the last log in a transaction, thus safe
+        const topics = logs[logIndexInTransaction + 1].topics;
+        return topics.length > 0 && topics[0] == LOG_REPAY_TOPIC0;
+    } else {
+        log.warning('Only LogRepay and LogRemoveCollateral can be a liquidation, but got topic0: {}. Transaction hash: {}, log index: {}', [
+            currentLog.topics[0].toHexString(),
+            event.transaction.hash.toHexString(),
+            logIndexInTransaction.toString(),
+        ]);
+        return false;
+    }
+}

--- a/subgraphs/cauldrons/subgraph.template.yaml
+++ b/subgraphs/cauldrons/subgraph.template.yaml
@@ -59,10 +59,12 @@ templates:
           handler: handleLogAddCollateral
         - event: LogRemoveCollateral(indexed address,indexed address,uint256)
           handler: handleLogRemoveCollateral
+          receipt: true
         - event: LogBorrow(indexed address,indexed address,uint256,uint256)
           handler: handleLogBorrow
         - event: LogRepay(indexed address,indexed address,uint256,uint256)
           handler: handleLogRepay
+          receipt: true
         - event: LogExchangeRate(uint256)
           handler: handleLogExchangeRate
         - event: LogAccrue(uint128)


### PR DESCRIPTION
 Adds support for liquidations in internal TXs. Iinstead of checking the method of the transaction call, it checks the transaction logs in the transaction receipt, and checks if it's a `LogRemoveCollateral` immediately followed by `LogRepay` or it's a `LogRepay` that is preceded by a `LogRemoveCollateral`. This **SHOULD** only be possible in liquidations, as `LogRemoveCollateral` is always followed by a `LogTransfer` from the bentobox when collateral is removed. Synced it on mainnet and avalanche, and there is quite a bit more liquidations.