### PR TITLE
feat(cauldrons): Add events

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "prepare": "husky install"
     },
     "dependencies": {
-        "@graphprotocol/graph-cli": "^0.57.0",
+        "@graphprotocol/graph-cli": "0.62.0",
         "@graphprotocol/graph-ts": "^0.31.0"
     },
     "devDependencies": {

--- a/packages/misc/constants.ts
+++ b/packages/misc/constants.ts
@@ -12,6 +12,7 @@ export const DEFAULT_DECIMALS = 18;
 
 export const BIGINT_ZERO = BigInt.fromI32(0);
 export const BIGINT_ONE = BigInt.fromI32(1);
+export const BIGINT_TEN = BigInt.fromI32(10);
 export const BIGINT_ONE_HUNDRED = BigInt.fromI32(100);
 export const BIGINT_18 = BigInt.fromI32(18);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@graphprotocol/graph-cli':
-        specifier: ^0.57.0
-        version: 0.57.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
+        specifier: 0.62.0
+        version: 0.62.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
       '@graphprotocol/graph-ts':
         specifier: ^0.31.0
         version: 0.31.0
@@ -42,11 +42,11 @@ importers:
   subgraphs/beam:
     dependencies:
       '@graphprotocol/graph-cli':
-        specifier: ^0.53.0
-        version: 0.53.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
+        specifier: 0.62.0
+        version: 0.62.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
       '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: ^0.31.0
+        version: 0.31.0
     devDependencies:
       abi:
         specifier: workspace:*
@@ -55,23 +55,20 @@ importers:
         specifier: ^0.19.20
         version: 0.19.20
       matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.0
+        version: 0.6.0
       misc:
         specifier: workspace:*
         version: link:../../packages/misc
-      wabt:
-        specifier: 1.0.24
-        version: 1.0.24
 
   subgraphs/blocks:
     dependencies:
       '@graphprotocol/graph-cli':
-        specifier: ^0.53.0
-        version: 0.53.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
+        specifier: 0.62.0
+        version: 0.62.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
       '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: ^0.31.0
+        version: 0.31.0
     devDependencies:
       abi:
         specifier: workspace:*
@@ -80,20 +77,17 @@ importers:
         specifier: ^0.19.20
         version: 0.19.20
       matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
-      wabt:
-        specifier: 1.0.24
-        version: 1.0.24
+        specifier: 0.6.0
+        version: 0.6.0
 
   subgraphs/cauldrons:
     dependencies:
       '@graphprotocol/graph-cli':
-        specifier: ^0.53.0
-        version: 0.53.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
+        specifier: 0.62.0
+        version: 0.62.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
       '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: ^0.31.0
+        version: 0.31.0
     devDependencies:
       abi:
         specifier: workspace:*
@@ -102,23 +96,20 @@ importers:
         specifier: ^0.19.20
         version: 0.19.20
       matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.0
+        version: 0.6.0
       misc:
         specifier: workspace:*
         version: link:../../packages/misc
-      wabt:
-        specifier: 1.0.24
-        version: 1.0.24
 
   subgraphs/level-finance:
     dependencies:
       '@graphprotocol/graph-cli':
-        specifier: ^0.53.0
-        version: 0.53.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
+        specifier: 0.62.0
+        version: 0.62.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
       '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: ^0.31.0
+        version: 0.31.0
     devDependencies:
       abi:
         specifier: workspace:*
@@ -127,23 +118,20 @@ importers:
         specifier: ^0.19.20
         version: 0.19.20
       matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.0
+        version: 0.6.0
       misc:
         specifier: workspace:*
         version: link:../../packages/misc
-      wabt:
-        specifier: 1.0.24
-        version: 1.0.24
 
   subgraphs/magic-ape:
     dependencies:
       '@graphprotocol/graph-cli':
-        specifier: ^0.53.0
-        version: 0.53.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
+        specifier: 0.62.0
+        version: 0.62.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
       '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: ^0.31.0
+        version: 0.31.0
     devDependencies:
       abi:
         specifier: workspace:*
@@ -152,23 +140,20 @@ importers:
         specifier: ^0.19.20
         version: 0.19.20
       matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.0
+        version: 0.6.0
       misc:
         specifier: workspace:*
         version: link:../../packages/misc
-      wabt:
-        specifier: 1.0.24
-        version: 1.0.24
 
   subgraphs/magic-glp:
     dependencies:
       '@graphprotocol/graph-cli':
-        specifier: ^0.53.0
-        version: 0.53.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
+        specifier: 0.62.0
+        version: 0.62.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
       '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: ^0.31.0
+        version: 0.31.0
     devDependencies:
       abi:
         specifier: workspace:*
@@ -177,23 +162,20 @@ importers:
         specifier: ^0.19.20
         version: 0.19.20
       matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.0
+        version: 0.6.0
       misc:
         specifier: workspace:*
         version: link:../../packages/misc
-      wabt:
-        specifier: 1.0.24
-        version: 1.0.24
 
   subgraphs/mspell:
     dependencies:
       '@graphprotocol/graph-cli':
-        specifier: ^0.53.0
-        version: 0.53.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
+        specifier: 0.62.0
+        version: 0.62.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
       '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: ^0.31.0
+        version: 0.31.0
     devDependencies:
       abi:
         specifier: workspace:*
@@ -202,23 +184,20 @@ importers:
         specifier: ^0.19.20
         version: 0.19.20
       matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.0
+        version: 0.6.0
       misc:
         specifier: workspace:*
         version: link:../../packages/misc
-      wabt:
-        specifier: 1.0.24
-        version: 1.0.24
 
   subgraphs/spell:
     dependencies:
       '@graphprotocol/graph-cli':
-        specifier: ^0.53.0
-        version: 0.53.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
+        specifier: 0.62.0
+        version: 0.62.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
       '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: ^0.31.0
+        version: 0.31.0
     devDependencies:
       abi:
         specifier: workspace:*
@@ -227,23 +206,20 @@ importers:
         specifier: ^0.19.20
         version: 0.19.20
       matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.0
+        version: 0.6.0
       misc:
         specifier: workspace:*
         version: link:../../packages/misc
-      wabt:
-        specifier: 1.0.24
-        version: 1.0.24
 
   subgraphs/sspell:
     dependencies:
       '@graphprotocol/graph-cli':
-        specifier: ^0.53.0
-        version: 0.53.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
+        specifier: 0.62.0
+        version: 0.62.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2)
       '@graphprotocol/graph-ts':
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: ^0.31.0
+        version: 0.31.0
     devDependencies:
       abi:
         specifier: workspace:*
@@ -252,22 +228,19 @@ importers:
         specifier: ^0.19.20
         version: 0.19.20
       matchstick-as:
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.0
+        version: 0.6.0
       misc:
         specifier: workspace:*
         version: link:../../packages/misc
-      wabt:
-        specifier: 1.0.24
-        version: 1.0.24
 
 packages:
 
-  /@babel/code-frame@7.22.13:
-    resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
+  /@babel/code-frame@7.23.5:
+    resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.22.20
+      '@babel/highlight': 7.23.4
       chalk: 2.4.2
     dev: false
 
@@ -276,8 +249,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/highlight@7.22.20:
-    resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
+  /@babel/highlight@7.23.4:
+    resolution: {integrity: sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-validator-identifier': 7.22.20
@@ -461,52 +434,9 @@ packages:
       js-yaml: 4.1.0
     dev: false
 
-  /@graphprotocol/graph-cli@0.53.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-K6mvEgaHrNlldbNfAL7DKQhJnp8mSuHkDwBXZm4tbdEbwKneItRObjIOEtgAcfK+Gei1mT6pTO4I+8N7tIg9XA==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dependencies:
-      '@float-capital/float-subgraph-uncrashable': 0.0.0-internal-testing.5
-      '@oclif/core': 2.8.6(@types/node@20.6.3)(typescript@5.2.2)
-      '@whatwg-node/fetch': 0.8.8
-      assemblyscript: 0.19.23
-      binary-install-raw: 0.0.13(debug@4.3.4)
-      chalk: 3.0.0
-      chokidar: 3.5.3
-      debug: 4.3.4(supports-color@8.1.1)
-      docker-compose: 0.23.19
-      dockerode: 2.5.8
-      fs-extra: 9.1.0
-      glob: 9.3.5
-      gluegun: 5.1.2(debug@4.3.4)
-      graphql: 15.5.0
-      immutable: 4.2.1
-      ipfs-http-client: 55.0.0(node-fetch@3.3.2)
-      jayson: 4.0.0
-      js-yaml: 3.14.1
-      prettier: 1.19.1
-      request: 2.88.2
-      semver: 7.4.0
-      sync-request: 6.1.0
-      tmp-promise: 3.0.3
-      web3-eth-abi: 1.7.0
-      which: 2.0.2
-      yaml: 1.10.2
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - node-fetch
-      - supports-color
-      - typescript
-      - utf-8-validate
-    dev: false
-
-  /@graphprotocol/graph-cli@0.57.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-UQ+4a4qTeGYdIWHNINtwTiL7izuRe4smgSeGmTxQQMSeebehTgrpa6NV3brGWcYsmN1Bo5egM4D9stkQtRnxeA==}
-    engines: {node: '>=14'}
+  /@graphprotocol/graph-cli@0.62.0(@types/node@20.6.3)(node-fetch@3.3.2)(typescript@5.2.2):
+    resolution: {integrity: sha512-dyjhkCSXbdcul5h1wY2CmorjM4k+tjjzEFs5GFBSSdLC2VodKXEWJo9RzrpFSmRBJzwc7ywDf8Pbmy1cJTCXRA==}
+    engines: {node: '>=18'}
     hasBin: true
     dependencies:
       '@float-capital/float-subgraph-uncrashable': 0.0.0-internal-testing.5
@@ -548,11 +478,6 @@ packages:
       - typescript
       - utf-8-validate
     dev: false
-
-  /@graphprotocol/graph-ts@0.27.0:
-    resolution: {integrity: sha512-r1SPDIZVQiGMxcY8rhFSM0y7d/xAbQf5vHMWUf59js1KgoyWpM6P3tczZqmQd7JTmeyNsDGIPzd9FeaxllsU4w==}
-    dependencies:
-      assemblyscript: 0.19.10
 
   /@graphprotocol/graph-ts@0.31.0:
     resolution: {integrity: sha512-xreRVM6ho2BtolyOh2flDkNoGZximybnzUnF53zJVp0+Ed0KnAlO1/KOCUYw06euVI9tk0c9nA2Z/D5SIQV2Rg==}
@@ -829,19 +754,19 @@ packages:
   /@types/concat-stream@1.6.1:
     resolution: {integrity: sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==}
     dependencies:
-      '@types/node': 8.10.66
+      '@types/node': 20.6.3
     dev: false
 
   /@types/connect@3.4.36:
     resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 20.6.3
     dev: false
 
   /@types/form-data@0.0.33:
     resolution: {integrity: sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==}
     dependencies:
-      '@types/node': 8.10.66
+      '@types/node': 20.6.3
     dev: false
 
   /@types/long@4.0.2:
@@ -891,7 +816,7 @@ packages:
   /@types/ws@7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 20.6.3
     dev: false
 
   /@whatwg-node/events@0.0.3:
@@ -1076,6 +1001,7 @@ packages:
     dependencies:
       binaryen: 101.0.0-nightly.20210723
       long: 4.0.0
+    dev: false
 
   /assemblyscript@0.19.20:
     resolution: {integrity: sha512-uull/pqWqKZkBC8pQM+oujNoRKC4bN+gv/cJ2Dl71fOzvCXqQN+q/36RpMzN4v5nryt8XoKwXQ8dbv4zGU1nbQ==}
@@ -1093,6 +1019,7 @@ packages:
       binaryen: 102.0.0-nightly.20211028
       long: 5.2.3
       source-map-support: 0.5.21
+    dev: false
 
   /assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
@@ -1172,6 +1099,7 @@ packages:
   /binaryen@101.0.0-nightly.20210723:
     resolution: {integrity: sha512-eioJNqhHlkguVSbblHOtLqlhtC882SOEPKmNFZaDuz1hzQjolxZ+eu3/kaS10n3sGPONsIZsO7R9fR00UyhEUA==}
     hasBin: true
+    dev: false
 
   /binaryen@102.0.0-nightly.20211028:
     resolution: {integrity: sha512-GCJBVB5exbxzzvyt8MGDv/MeUjs6gkXDvf4xOIItRBptYl0Tz5sm1o/uG95YK0L0VeG5ajDu3hRtkBP2kzqC5w==}
@@ -2719,6 +2647,7 @@ packages:
 
   /long@4.0.0:
     resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
+    dev: false
 
   /long@5.2.3:
     resolution: {integrity: sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==}
@@ -2739,11 +2668,9 @@ packages:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: false
 
-  /matchstick-as@0.5.0:
-    resolution: {integrity: sha512-4K619YDH+so129qt4RB4JCNxaFwJJYLXPc7drpG+/mIj86Cfzg6FKs/bA91cnajmS1CLHdhHl9vt6Kd6Oqvfkg==}
+  /matchstick-as@0.6.0:
+    resolution: {integrity: sha512-E36fWsC1AbCkBFt05VsDDRoFvGSdcZg6oZJrtIe/YDBbuFh8SKbR5FcoqDhNWqSN+F7bN/iS2u8Md0SM+4pUpw==}
     dependencies:
-      '@graphprotocol/graph-ts': 0.27.0
-      assemblyscript: 0.19.23
       wabt: 1.0.24
     dev: true
 
@@ -3077,7 +3004,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.23.5
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4

--- a/subgraphs/beam/package.json
+++ b/subgraphs/beam/package.json
@@ -18,13 +18,12 @@
     "deploy:studio": "graph deploy --node https://api.studio.thegraph.com/deploy/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.53.0",
-    "@graphprotocol/graph-ts": "^0.27.0"
+    "@graphprotocol/graph-cli": "0.62.0",
+    "@graphprotocol/graph-ts": "^0.31.0"
   },
   "devDependencies": {
-    "matchstick-as": "0.5.0",
+    "matchstick-as": "0.6.0",
     "assemblyscript": "^0.19.20",
-    "wabt": "1.0.24",
     "abi": "workspace:*",
     "misc": "workspace:*"
   }

--- a/subgraphs/blocks/package.json
+++ b/subgraphs/blocks/package.json
@@ -16,13 +16,12 @@
     "test": "graph test -r"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.53.0",
-    "@graphprotocol/graph-ts": "^0.27.0"
+    "@graphprotocol/graph-cli": "0.62.0",
+    "@graphprotocol/graph-ts": "^0.31.0"
   },
   "devDependencies": {
-    "matchstick-as": "0.5.0",
+    "matchstick-as": "0.6.0",
     "assemblyscript": "^0.19.20",
-    "wabt": "1.0.24",
     "abi": "workspace:*"
   }
 }

--- a/subgraphs/cauldrons/package.json
+++ b/subgraphs/cauldrons/package.json
@@ -18,13 +18,12 @@
     "deploy:studio": "graph deploy --node https://api.studio.thegraph.com/deploy/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.53.0",
-    "@graphprotocol/graph-ts": "^0.27.0"
+    "@graphprotocol/graph-cli": "0.62.0",
+    "@graphprotocol/graph-ts": "^0.31.0"
   },
   "devDependencies": {
-    "matchstick-as": "0.5.0",
+    "matchstick-as": "0.6.0",
     "assemblyscript": "^0.19.20",
-    "wabt": "1.0.24",
     "abi": "workspace:*",
     "misc": "workspace:*"
   }

--- a/subgraphs/cauldrons/schema.graphql
+++ b/subgraphs/cauldrons/schema.graphql
@@ -18,6 +18,9 @@ type Protocol @entity {
   " Total number of cauldrons "
   totalCauldronCount: BigInt!
 
+  " All bentoboxes that belong to this protocol "
+  bentoBoxes: [BentoBox!]! @derivedFrom(field: "protocol")
+
   " All cauldrons that belong to this protocol "
   cauldrons: [Cauldron!]! @derivedFrom(field: "protocol")
 
@@ -103,9 +106,21 @@ type ProtocolHourySnapshot @entity{
     totalFeesGenerated: BigDecimal!
 }
 
+type BentoBox @entity {
+  " Contract address of the bentoBox "
+  id: ID!
+
+  protocol: Protocol!
+
+  cauldrons: [Cauldron!]! @derivedFrom(field: "bentoBox")
+}
+
 type Cauldron @entity {
   " Smart contract address of the cauldron "
   id: ID!
+
+  " BentoBox used by the cauldron "
+  bentoBox: BentoBox!
 
   " Master contract address of the cauldron "
   masterContract: Bytes!
@@ -187,6 +202,16 @@ type Cauldron @entity {
   totalMimBorrowed: BigDecimal!
 
   totalCollateralShare: BigDecimal!
+
+  addCollateralEvents: [AddCollateralEvent!]! @derivedFrom(field: "cauldron")
+
+  removeCollateralEvents: [RemoveCollateralEvent!]! @derivedFrom(field: "cauldron")
+
+  borrowEvents: [BorrowEvent!]! @derivedFrom(field: "cauldron")
+
+  repayEvents: [RepayEvent!]! @derivedFrom(field: "cauldron")
+
+  liquidationEvents: [LiquidationEvent!]! @derivedFrom(field: "cauldron")
 }
 
 type CauldronDailySnapshot @entity {
@@ -323,6 +348,16 @@ type Account @entity {
 
   " Number of times this account has been liquidated "
   liquidationCount: BigInt!
+
+  addCollateralEvents: [AddCollateralEvent!]! @derivedFrom(field: "account")
+
+  removeCollateralEvents: [RemoveCollateralEvent!]! @derivedFrom(field: "account")
+
+  borrowEvents: [BorrowEvent!]! @derivedFrom(field: "account")
+
+  repayEvents: [RepayEvent!]! @derivedFrom(field: "account")
+
+  liquidationEvents: [LiquidationEvent!]! @derivedFrom(field: "account")
 }
 
 type AccountState @entity {
@@ -343,6 +378,166 @@ type AccountState @entity {
 
   " Position daily snapshots for open positions "
   snapshots: [AccountStateSnapshot!]! @derivedFrom(field: "state")
+
+  addCollateralEvents: [AddCollateralEvent!]! @derivedFrom(field: "accountState")
+
+  removeCollateralEvents: [RemoveCollateralEvent!]! @derivedFrom(field: "accountState")
+
+  borrowEvents: [BorrowEvent!]! @derivedFrom(field: "accountState")
+
+  repayEvents: [RepayEvent!]! @derivedFrom(field: "accountState")
+
+  liquidationEvents: [LiquidationEvent!]! @derivedFrom(field: "accountState")
+}
+
+interface Event {
+  id: ID!
+
+  blockNumber: BigInt!
+
+  transactionHash: Bytes!
+
+  logIndex: BigInt!
+
+  timestamp: BigInt!
+
+  cauldron: Cauldron!
+
+  account: Account!
+
+  accountState: AccountState!
+}
+
+type AddCollateralEvent implements Event @entity(immutable: true) {
+  id: ID!
+
+  blockNumber: BigInt!
+
+  transactionHash: Bytes!
+
+  logIndex: BigInt!
+
+  timestamp: BigInt!
+
+  cauldron: Cauldron!
+
+  account: Account!
+
+  accountState: AccountState!
+
+  from: Bytes!
+
+  share: BigInt!
+
+  amount: BigInt!
+
+  amountUsd: BigDecimal
+}
+
+type RemoveCollateralEvent implements Event @entity(immutable: true) {
+  id: ID!
+
+  blockNumber: BigInt!
+
+  transactionHash: Bytes!
+
+  logIndex: BigInt!
+
+  timestamp: BigInt!
+
+  cauldron: Cauldron!
+
+  account: Account!
+
+  accountState: AccountState!
+
+  to: Bytes!
+
+  share: BigInt!
+
+  amount: BigInt!
+
+  amountUsd: BigDecimal
+}
+
+type BorrowEvent implements Event @entity(immutable: true) {
+  id: ID!
+
+  blockNumber: BigInt!
+
+  transactionHash: Bytes!
+
+  logIndex: BigInt!
+
+  timestamp: BigInt!
+
+  cauldron: Cauldron!
+
+  account: Account!
+
+  accountState: AccountState!
+
+  to: Bytes!
+
+  amount: BigInt!
+
+  part: BigInt!
+}
+
+type RepayEvent implements Event @entity(immutable: true) {
+  id: ID!
+
+  blockNumber: BigInt!
+
+  transactionHash: Bytes!
+
+  logIndex: BigInt!
+
+  timestamp: BigInt!
+
+  cauldron: Cauldron!
+
+  account: Account!
+
+  accountState: AccountState!
+
+  from: Bytes!
+
+  amount: BigInt!
+
+  part: BigInt!
+}
+
+type LiquidationEvent implements Event @entity(immutable: true) {
+  id: ID!
+
+  blockNumber: BigInt!
+
+  transactionHash: Bytes!
+
+  logIndex: BigInt!
+
+  timestamp: BigInt!
+
+  cauldron: Cauldron!
+
+  account: Account!
+
+  accountState: AccountState!
+
+  liquidator: Bytes!
+
+  to: Bytes!
+
+  liquidateShare: BigInt!
+
+  liquidateAmount: BigInt!
+
+  liquidateAmountUsd: BigDecimal
+
+  repayAmount: BigInt!
+
+  repayPart: BigInt!
 }
 
 type AccountStateSnapshot @entity {

--- a/subgraphs/cauldrons/src/helpers/bentobox/get-or-create-bento-box.ts
+++ b/subgraphs/cauldrons/src/helpers/bentobox/get-or-create-bento-box.ts
@@ -1,0 +1,13 @@
+import { Address } from '@graphprotocol/graph-ts';
+import { BentoBox, Protocol } from '../../../generated/schema';
+
+export function getOrCreateBentoBox(address: Address, protocol: Protocol): BentoBox {
+    const id = address.toHexString();
+    let bentoBox = BentoBox.load(id);
+    if (bentoBox == null) {
+        bentoBox = new BentoBox(id);
+        bentoBox.protocol = protocol.id;
+        bentoBox.save();
+    }
+    return bentoBox;
+}

--- a/subgraphs/cauldrons/src/helpers/bentobox/index.ts
+++ b/subgraphs/cauldrons/src/helpers/bentobox/index.ts
@@ -1,0 +1,1 @@
+export * from './get-or-create-bento-box';

--- a/subgraphs/cauldrons/src/helpers/cauldron/create-cauldron.ts
+++ b/subgraphs/cauldrons/src/helpers/cauldron/create-cauldron.ts
@@ -3,12 +3,13 @@ import { Cauldron as CauldronSchema } from '../../../generated/schema';
 import { Cauldron } from '../../../generated/templates';
 import { Cauldron as CauldronTemplate } from '../../../generated/templates/Cauldron/Cauldron';
 import { CAULDRON_V1_BORROW_PARAMETERS } from '../../constants';
+import { getOrCreateBentoBox } from '../bentobox';
 import { getOrCreateCollateral } from '../collateral';
 import { getOrCreateProtocol } from '../protocol';
 import { BIGDECIMAL_ZERO, BIGINT_ZERO, BIGINT_ONE } from 'misc';
 import { CauldronDefinition, decodeCauldronInitV1, decodeCauldronInitV2Plus } from '../../utils';
 
-export function createCauldron(cauldronAddress: Address, masterContract: Address, blockNumber: BigInt, blockTimestamp: BigInt, data: Bytes): void {
+export function createCauldron(cauldronAddress: Address, bentoBoxAddress: Address, masterContract: Address, blockNumber: BigInt, blockTimestamp: BigInt, data: Bytes): void {
     const CauldronContract = CauldronTemplate.bind(cauldronAddress);
 
     const masterContractChainAddress = `${dataSource.network()}:${masterContract.toHexString()}`.toLowerCase();
@@ -25,8 +26,10 @@ export function createCauldron(cauldronAddress: Address, masterContract: Address
 
     const CauldronEntity = new CauldronSchema(cauldronAddress.toHexString());
     const protocol = getOrCreateProtocol();
+    const bentoBox = getOrCreateBentoBox(bentoBoxAddress, protocol);
 
     const collateral = getOrCreateCollateral(cauldronDefinition.collateral);
+    CauldronEntity.bentoBox = bentoBox.id;
     CauldronEntity.masterContract = masterContract;
     CauldronEntity.collateral = collateral.id;
     CauldronEntity.name = collateral.symbol;

--- a/subgraphs/cauldrons/src/helpers/events/create-add-collateral-event.ts
+++ b/subgraphs/cauldrons/src/helpers/events/create-add-collateral-event.ts
@@ -1,0 +1,19 @@
+import { AddCollateralEvent } from '../../../generated/schema';
+import { LogAddCollateral } from '../../../generated/templates/Cauldron/Cauldron';
+import { fillEvent } from './fill-event';
+import { getAmount } from './get-amount';
+import { getUsdAmount } from './get-usd-amount';
+
+export function createAddCollateralEvent(contractEvent: LogAddCollateral): AddCollateralEvent {
+    const addCollateralEvent = new AddCollateralEvent(`${contractEvent.transaction.hash.toHexString()}-${contractEvent.logIndex}`);
+    fillEvent(contractEvent, contractEvent.params.to, addCollateralEvent);
+    addCollateralEvent.from = contractEvent.params.from;
+    addCollateralEvent.share = contractEvent.params.share;
+
+    const amount = getAmount(contractEvent.address, contractEvent.params.share, false);
+    addCollateralEvent.amount = amount;
+    addCollateralEvent.amountUsd = getUsdAmount(contractEvent.address, amount);
+
+    addCollateralEvent.save();
+    return addCollateralEvent;
+}

--- a/subgraphs/cauldrons/src/helpers/events/create-borrow-event.ts
+++ b/subgraphs/cauldrons/src/helpers/events/create-borrow-event.ts
@@ -1,0 +1,13 @@
+import { BorrowEvent } from '../../../generated/schema';
+import { LogBorrow } from '../../../generated/templates/Cauldron/Cauldron';
+import { fillEvent } from './fill-event';
+
+export function createBorrowEvent(contractEvent: LogBorrow): BorrowEvent {
+    const borrowEvent = new BorrowEvent(`${contractEvent.transaction.hash.toHexString()}-${contractEvent.logIndex}`);
+    fillEvent(contractEvent, contractEvent.params.from, borrowEvent);
+    borrowEvent.to = contractEvent.params.to;
+    borrowEvent.amount = contractEvent.params.amount;
+    borrowEvent.part = contractEvent.params.part;
+    borrowEvent.save();
+    return borrowEvent;
+}

--- a/subgraphs/cauldrons/src/helpers/events/create-liquidation-event.ts
+++ b/subgraphs/cauldrons/src/helpers/events/create-liquidation-event.ts
@@ -1,0 +1,19 @@
+import { LiquidationEvent, RemoveCollateralEvent } from '../../../generated/schema';
+import { LogRepay } from '../../../generated/templates/Cauldron/Cauldron';
+import { fillEvent } from './fill-event';
+
+export function createLiquidationEvent(contractEvent: LogRepay, removeCollateralEvent: RemoveCollateralEvent): LiquidationEvent {
+    const liquidationEvent = new LiquidationEvent(`${contractEvent.transaction.hash.toHexString()}-${contractEvent.logIndex}`);
+    fillEvent(contractEvent, contractEvent.params.to, liquidationEvent);
+    liquidationEvent.liquidator = contractEvent.params.from;
+    liquidationEvent.to = removeCollateralEvent.to;
+    liquidationEvent.liquidateShare = removeCollateralEvent.share;
+    liquidationEvent.liquidateAmount = removeCollateralEvent.amount;
+    liquidationEvent.liquidateAmountUsd = removeCollateralEvent.amountUsd;
+
+    liquidationEvent.repayAmount = contractEvent.params.amount;
+    liquidationEvent.repayPart = contractEvent.params.part;
+
+    liquidationEvent.save();
+    return liquidationEvent;
+}

--- a/subgraphs/cauldrons/src/helpers/events/create-remove-collateral-event.ts
+++ b/subgraphs/cauldrons/src/helpers/events/create-remove-collateral-event.ts
@@ -1,0 +1,19 @@
+import { RemoveCollateralEvent } from '../../../generated/schema';
+import { LogRemoveCollateral } from '../../../generated/templates/Cauldron/Cauldron';
+import { fillEvent } from './fill-event';
+import { getAmount } from './get-amount';
+import { getUsdAmount } from './get-usd-amount';
+
+export function createRemoveCollateralEvent(contractEvent: LogRemoveCollateral): RemoveCollateralEvent {
+    const removeCollateralEvent = new RemoveCollateralEvent(`${contractEvent.transaction.hash.toHexString()}-${contractEvent.logIndex}`);
+    fillEvent(contractEvent, contractEvent.params.from, removeCollateralEvent);
+    removeCollateralEvent.to = contractEvent.params.to;
+    removeCollateralEvent.share = contractEvent.params.share;
+
+    const amount = getAmount(contractEvent.address, contractEvent.params.share, false);
+    removeCollateralEvent.amount = amount;
+    removeCollateralEvent.amountUsd = getUsdAmount(contractEvent.address, amount);
+
+    removeCollateralEvent.save();
+    return removeCollateralEvent;
+}

--- a/subgraphs/cauldrons/src/helpers/events/create-repay-event.ts
+++ b/subgraphs/cauldrons/src/helpers/events/create-repay-event.ts
@@ -1,0 +1,13 @@
+import { RepayEvent } from '../../../generated/schema';
+import { LogRepay } from '../../../generated/templates/Cauldron/Cauldron';
+import { fillEvent } from './fill-event';
+
+export function createRepayEvent(contractEvent: LogRepay): RepayEvent {
+    const repayEvent = new RepayEvent(`${contractEvent.transaction.hash.toHexString()}-${contractEvent.logIndex}`);
+    fillEvent(contractEvent, contractEvent.params.to, repayEvent);
+    repayEvent.from = contractEvent.params.from;
+    repayEvent.amount = contractEvent.params.amount;
+    repayEvent.part = contractEvent.params.part;
+    repayEvent.save();
+    return repayEvent;
+}

--- a/subgraphs/cauldrons/src/helpers/events/fill-event.ts
+++ b/subgraphs/cauldrons/src/helpers/events/fill-event.ts
@@ -1,0 +1,13 @@
+import { Address, Entity, ethereum } from '@graphprotocol/graph-ts';
+
+export function fillEvent(contractEvent: ethereum.Event, account: Address, entityEvent: Entity): void {
+    const cauldronAddress = contractEvent.address.toHexString();
+
+    entityEvent.setBigInt('blockNumber', contractEvent.block.number);
+    entityEvent.setBytes('transactionHash', contractEvent.transaction.hash);
+    entityEvent.setBigInt('logIndex', contractEvent.logIndex);
+    entityEvent.setBigInt('timestamp', contractEvent.block.timestamp);
+    entityEvent.setString('cauldron', cauldronAddress);
+    entityEvent.setString('account', account.toHexString());
+    entityEvent.setString('accountState', `${cauldronAddress}-${account.toHexString()}`);
+}

--- a/subgraphs/cauldrons/src/helpers/events/get-amount.ts
+++ b/subgraphs/cauldrons/src/helpers/events/get-amount.ts
@@ -1,0 +1,9 @@
+import { Address, BigInt } from '@graphprotocol/graph-ts';
+import { BentoBox } from '../../../generated/templates/Cauldron/BentoBox';
+import { Cauldron } from '../../../generated/templates/Cauldron/Cauldron';
+
+export function getAmount(cauldron: Address, share: BigInt, roundUp: boolean): BigInt {
+    const cauldronContract = Cauldron.bind(cauldron);
+    const bentoBoxContract = BentoBox.bind(cauldronContract.bentoBox());
+    return bentoBoxContract.toAmount(cauldronContract.collateral(), share, roundUp);
+}

--- a/subgraphs/cauldrons/src/helpers/events/get-usd-amount.ts
+++ b/subgraphs/cauldrons/src/helpers/events/get-usd-amount.ts
@@ -1,0 +1,18 @@
+import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts';
+import { Cauldron } from '../../../generated/templates/Cauldron/Cauldron';
+import { ERC20 } from '../../../generated/templates/Cauldron/ERC20';
+import { Oracle } from '../../../generated/templates/Cauldron/Oracle';
+import { BIGINT_TEN, bigIntToBigDecimal } from 'misc';
+
+export function getUsdAmount(cauldron: Address, amount: BigInt): BigDecimal | null {
+    const cauldronContract = Cauldron.bind(cauldron);
+    const collateralContract = ERC20.bind(cauldronContract.collateral());
+    const collateralDecimals = collateralContract.decimals() as u8;
+    const oracle = Oracle.bind(cauldronContract.oracle());
+    const peekSpotValue = oracle.try_peekSpot(cauldronContract.oracleData());
+    if (peekSpotValue.reverted) {
+        return null;
+    }
+    const usdAmount = amount.times(BIGINT_TEN.pow(collateralDecimals)).div(peekSpotValue.value);
+    return bigIntToBigDecimal(usdAmount, collateralDecimals);
+}

--- a/subgraphs/cauldrons/src/helpers/events/index.ts
+++ b/subgraphs/cauldrons/src/helpers/events/index.ts
@@ -1,0 +1,5 @@
+export * from './create-add-collateral-event';
+export * from './create-borrow-event';
+export * from './create-liquidation-event';
+export * from './create-remove-collateral-event';
+export * from './create-repay-event';

--- a/subgraphs/cauldrons/src/mappings/core.ts
+++ b/subgraphs/cauldrons/src/mappings/core.ts
@@ -6,6 +6,6 @@ export function handleLogDeploy(event: LogDeploy): void {
     const account = event.transaction.from.toHex().toLowerCase();
 
     if (ABRA_DEPLOYERS.includes(account)) {
-        createCauldron(event.params.cloneAddress, event.params.masterContract, event.block.number, event.block.timestamp, event.params.data);
+        createCauldron(event.params.cloneAddress, event.address, event.params.masterContract, event.block.number, event.block.timestamp, event.params.data);
     }
 }

--- a/subgraphs/cauldrons/tests/constants.ts
+++ b/subgraphs/cauldrons/tests/constants.ts
@@ -2,6 +2,7 @@ import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts';
 
 export const CAULDRON_ENTITY = 'Cauldron';
 export const PROTOCOL_ENTITY = 'Protocol';
+export const BENTO_BOX_ENTITY = 'BentoBox';
 export const COLLATERAL_ENTITY = 'Collateral';
 export const PROTOCOL_DAILY_SNAPSHOT_ENTITY = 'ProtocolDailySnapshot';
 export const PROTOCOL_HOURY_SNAPSHOT_ENTITY = 'ProtocolHourySnapshot';
@@ -12,6 +13,11 @@ export const COLLATERAL_HOURY_SNAPSHOT_ENTITY = 'CollateralHourySnapshot';
 export const ACCOUNT_ENTITY = 'Account';
 export const ACCOUNT_STATE_ENTITY = 'AccountState';
 export const ACCOUNT_STATE_SNAPSHOT_ENTITY = 'AccountStateSnapshot';
+export const ADD_COLLATERAL_EVENT_ENTITY = 'AddCollateralEvent';
+export const REMOVE_COLLATERAL_EVENT_ENTITY = 'RemoveCollateralEvent';
+export const BORROW_EVENT_ENTITY = 'BorrowEvent';
+export const REPAY_EVENT_ENTITY = 'RepayEvent';
+export const LIQUIDATION_EVENT_ENTITY = 'LiquidationEvent';
 
 export const MOCK_ACCOUNT = Address.fromString('0x33C52FBAB377F2C9F85DD6E678AE6BAF78A20EBE');
 
@@ -25,6 +31,7 @@ export const CAULDRON_V1_DATA = Bytes.fromHexString(
     '0x0000000000000000000000007da96a3891add058ada2e826306d812c638d87a70000000000000000000000006cc0cd7d25e291029b55c767b9a2d1d9a18ae6680000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003e7d1eab13ad0104d2750b8863b489d65364e32d000000000000000000000000000000000001ed09bead87c0378d8e64000000000000000000000000000000007da96a3891add058ada2e826306d812c638d87a7',
 );
 export const CLONE_ADDRESS = Address.fromString('0xCfc571f3203756319c231d3Bc643Cee807E74636');
+export const BENTO_BOX_ADDRESS = Address.fromString('0xd96f48665a1410C0cd669A88898ecA36B9Fc2cce');
 export const SPELL_ORACLE_ADDRESS = Address.fromString('0x75e14253de6a5c2af12d5f1a1ea0a2e11e69ec10');
 export const SPELL_ORACLE_DATA = Bytes.fromHexString('0x00');
 export const SPELL_ORACLE_PRICE = BigInt.fromString('2131832523236974503283');
@@ -34,6 +41,7 @@ export const NON_CAULDRON_V1_COLLATERAL_ADDRESS = Address.fromString('0x090185f2
 export const CAULDRON_V1_COLLATERAL_ADDRESS = Address.fromString('0x7Da96a3891Add058AdA2E826306D812C638D87a7');
 
 // Mock collateral params
+export const COLLATERAL_ADDRESS = Address.fromString('0x090185f2135308BaD17527004364eBcC2D37e5F6');
 export const COLLATERAL_NAME = 'Spell Token';
 export const COLLATERAL_SYMBOL = 'SPELL';
 export const COLLATERAL_DECIMALS = 18;
@@ -41,6 +49,14 @@ export const COLLATERAL_DECIMALS = 18;
 // Mock block params
 export const BLOCK_NUMBER = BigInt.fromI32(13492855);
 export const BLOCK_TIMESTAMP = BigInt.fromI32(1635249440);
+
+// Mock event params
+export const EVENT_LOG_INDEX = BigInt.fromI32(12);
+export const REMOVE_COLLATERAL_EVENT_LOG_INDEX = BigInt.fromI32(0);
+export const REPAY_EVENT_LOG_INDEX = BigInt.fromI32(1);
+
+// Mock transaction params
+export const TRANSACTION_HASH = Bytes.fromHexString('0xe257c692a8d10445663ad0eca7024d5d61d46806b76241140c8ef69ddda1b823');
 
 // Mock cook borrow
 export const MOCK_COOK_BORROW = Bytes.fromHexString(

--- a/subgraphs/cauldrons/tests/core.test.ts
+++ b/subgraphs/cauldrons/tests/core.test.ts
@@ -6,6 +6,8 @@ import { getOrCreateCollateral } from '../src/helpers/collateral';
 import { getOrCreateProtocol } from '../src/helpers/protocol';
 import { handleLogDeploy } from '../src/mappings/core';
 import {
+    BENTO_BOX_ADDRESS,
+    BENTO_BOX_ENTITY,
     CAULDRON_ENTITY,
     CAULDRON_V1_COLLATERAL_ADDRESS,
     CAULDRON_V1_DATA,
@@ -57,6 +59,18 @@ describe('handleLogDeploy()', () => {
             assert.fieldEquals(PROTOCOL_ENTITY, protocolId, 'totalCauldronCount', '1');
             assert.fieldEquals(PROTOCOL_ENTITY, protocolId, 'cumulativeUniqueUsers', '0');
             assert.fieldEquals(PROTOCOL_ENTITY, protocolId, 'liquidationCount', '0');
+        });
+
+        test('should create bentobox', () => {
+            const newLogDeployEvent = createLogDeploy(NON_CAULDRON_V1_MASTER_CONTRACT_ADDRESS, NON_CAULDRON_V1_DATA, CLONE_ADDRESS);
+
+            handleLogDeploy(newLogDeployEvent);
+
+            const protocolId = getOrCreateProtocol().id;
+
+            assert.entityCount(BENTO_BOX_ENTITY, 1);
+            const bentBoxId = BENTO_BOX_ADDRESS.toHexString();
+            assert.fieldEquals(BENTO_BOX_ENTITY, bentBoxId, 'protocol', protocolId);
         });
 
         test('should create collateral', () => {
@@ -141,6 +155,18 @@ describe('handleLogDeploy()', () => {
             assert.fieldEquals(PROTOCOL_ENTITY, protocolId, 'totalCauldronCount', '1');
             assert.fieldEquals(PROTOCOL_ENTITY, protocolId, 'cumulativeUniqueUsers', '0');
             assert.fieldEquals(PROTOCOL_ENTITY, protocolId, 'liquidationCount', '0');
+        });
+
+        test('should create bentobox', () => {
+            const newLogDeployEvent = createLogDeploy(CAULDRON_V1_MASTER_CONTRACT_ADDRESS, CAULDRON_V1_DATA, CLONE_ADDRESS);
+
+            handleLogDeploy(newLogDeployEvent);
+
+            const protocolId = getOrCreateProtocol().id;
+
+            assert.entityCount(BENTO_BOX_ENTITY, 1);
+            const bentBoxId = BENTO_BOX_ADDRESS.toHexString();
+            assert.fieldEquals(BENTO_BOX_ENTITY, bentBoxId, 'protocol', protocolId);
         });
 
         test('should create collateral', () => {

--- a/subgraphs/cauldrons/tests/helpers/create-log-add-collateral.ts
+++ b/subgraphs/cauldrons/tests/helpers/create-log-add-collateral.ts
@@ -1,13 +1,15 @@
 import { BigInt, ethereum } from '@graphprotocol/graph-ts';
 import { newMockEvent } from 'matchstick-as/assembly';
 import { LogAddCollateral } from '../../generated/templates/Cauldron/Cauldron';
-import { BLOCK_NUMBER, BLOCK_TIMESTAMP, CLONE_ADDRESS, MOCK_ACCOUNT } from '../constants';
+import { BLOCK_NUMBER, BLOCK_TIMESTAMP, CLONE_ADDRESS, EVENT_LOG_INDEX, MOCK_ACCOUNT, TRANSACTION_HASH } from '../constants';
 
 export function createLogAddCollateral(): LogAddCollateral {
     const log: LogAddCollateral = changetype<LogAddCollateral>(newMockEvent());
 
     log.block.number = BLOCK_NUMBER;
     log.block.timestamp = BLOCK_TIMESTAMP;
+    log.logIndex = EVENT_LOG_INDEX;
+    log.transaction.hash = TRANSACTION_HASH;
     log.address = CLONE_ADDRESS;
 
     log.parameters = new Array();

--- a/subgraphs/cauldrons/tests/helpers/create-log-borrow.ts
+++ b/subgraphs/cauldrons/tests/helpers/create-log-borrow.ts
@@ -1,13 +1,15 @@
 import { BigInt, ethereum } from '@graphprotocol/graph-ts';
 import { newMockEvent } from 'matchstick-as/assembly';
 import { LogBorrow } from '../../generated/templates/Cauldron/Cauldron';
-import { BLOCK_NUMBER, BLOCK_TIMESTAMP, CLONE_ADDRESS, MOCK_ACCOUNT } from '../constants';
+import { BLOCK_NUMBER, BLOCK_TIMESTAMP, CLONE_ADDRESS, EVENT_LOG_INDEX, MOCK_ACCOUNT, TRANSACTION_HASH } from '../constants';
 
 export function createLogBorrow(): LogBorrow {
     const logBorrowEvent: LogBorrow = changetype<LogBorrow>(newMockEvent());
 
     logBorrowEvent.block.number = BLOCK_NUMBER;
     logBorrowEvent.block.timestamp = BLOCK_TIMESTAMP;
+    logBorrowEvent.logIndex = EVENT_LOG_INDEX;
+    logBorrowEvent.transaction.hash = TRANSACTION_HASH;
     logBorrowEvent.address = CLONE_ADDRESS;
 
     logBorrowEvent.parameters = new Array();

--- a/subgraphs/cauldrons/tests/helpers/create-log-deploy.ts
+++ b/subgraphs/cauldrons/tests/helpers/create-log-deploy.ts
@@ -2,7 +2,7 @@ import { newMockEvent } from 'matchstick-as';
 import { ethereum, Address, Bytes } from '@graphprotocol/graph-ts';
 import { LogDeploy } from '../../generated/BentoBox/BentoBox';
 import { ABRA_DEPLOYERS } from '../../src/constants';
-import { BLOCK_NUMBER, BLOCK_TIMESTAMP } from '../constants';
+import { BENTO_BOX_ADDRESS, BLOCK_NUMBER, BLOCK_TIMESTAMP } from '../constants';
 
 export function createLogDeploy(masterContract: Address, data: Bytes, cloneAddress: Address): LogDeploy {
     const logDeployEvent: LogDeploy = changetype<LogDeploy>(newMockEvent());
@@ -10,6 +10,7 @@ export function createLogDeploy(masterContract: Address, data: Bytes, cloneAddre
     logDeployEvent.transaction.from = Address.fromString(ABRA_DEPLOYERS[0]);
     logDeployEvent.block.number = BLOCK_NUMBER;
     logDeployEvent.block.timestamp = BLOCK_TIMESTAMP;
+    logDeployEvent.address = BENTO_BOX_ADDRESS;
 
     logDeployEvent.parameters = new Array();
 

--- a/subgraphs/cauldrons/tests/helpers/create-log-remove-collateral.ts
+++ b/subgraphs/cauldrons/tests/helpers/create-log-remove-collateral.ts
@@ -1,16 +1,16 @@
 import { Address, BigInt, Bytes, ethereum } from '@graphprotocol/graph-ts';
 import { newMockEvent } from 'matchstick-as/assembly';
 import { LogRemoveCollateral } from '../../generated/templates/Cauldron/Cauldron';
-import { BLOCK_NUMBER, BLOCK_TIMESTAMP, CLONE_ADDRESS, MOCK_ACCOUNT } from '../constants';
+import { BLOCK_NUMBER, BLOCK_TIMESTAMP, CLONE_ADDRESS, REMOVE_COLLATERAL_EVENT_LOG_INDEX, MOCK_ACCOUNT, TRANSACTION_HASH } from '../constants';
 
 export function createLogRemoveCollateral(): LogRemoveCollateral {
     const log: LogRemoveCollateral = changetype<LogRemoveCollateral>(newMockEvent());
 
     log.block.number = BLOCK_NUMBER;
     log.block.timestamp = BLOCK_TIMESTAMP;
+    log.logIndex = REMOVE_COLLATERAL_EVENT_LOG_INDEX;
+    log.transaction.hash = TRANSACTION_HASH;
     log.address = CLONE_ADDRESS;
-
-    log.logIndex = BigInt.fromI32(0);
 
     const eventLogs: ethereum.Log[] = [
         new ethereum.Log(

--- a/subgraphs/cauldrons/tests/helpers/create-log-repay.ts
+++ b/subgraphs/cauldrons/tests/helpers/create-log-repay.ts
@@ -1,16 +1,16 @@
 import { Address, BigInt, Bytes, ethereum } from '@graphprotocol/graph-ts';
 import { newMockEvent } from 'matchstick-as/assembly';
 import { LogRepay } from '../../generated/templates/Cauldron/Cauldron';
-import { BLOCK_NUMBER, BLOCK_TIMESTAMP, CLONE_ADDRESS, MOCK_ACCOUNT } from '../constants';
+import { BLOCK_NUMBER, BLOCK_TIMESTAMP, CLONE_ADDRESS, REPAY_EVENT_LOG_INDEX, MOCK_ACCOUNT, TRANSACTION_HASH } from '../constants';
 
 export function createLogRepay(): LogRepay {
     const log: LogRepay = changetype<LogRepay>(newMockEvent());
 
     log.block.number = BLOCK_NUMBER;
     log.block.timestamp = BLOCK_TIMESTAMP;
+    log.logIndex = REPAY_EVENT_LOG_INDEX;
+    log.transaction.hash = TRANSACTION_HASH;
     log.address = CLONE_ADDRESS;
-
-    log.logIndex = BigInt.fromI32(1);
 
     const eventLogs: ethereum.Log[] = [
         new ethereum.Log(

--- a/subgraphs/level-finance/package.json
+++ b/subgraphs/level-finance/package.json
@@ -18,13 +18,12 @@
     "deploy:studio": "graph deploy --node https://api.studio.thegraph.com/deploy/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.53.0",
-    "@graphprotocol/graph-ts": "^0.27.0"
+    "@graphprotocol/graph-cli": "0.62.0",
+    "@graphprotocol/graph-ts": "^0.31.0"
   },
   "devDependencies": {
-    "matchstick-as": "0.5.0",
+    "matchstick-as": "0.6.0",
     "assemblyscript": "^0.19.20",
-    "wabt": "1.0.24",
     "abi": "workspace:*",
     "misc": "workspace:*"
   }

--- a/subgraphs/magic-ape/package.json
+++ b/subgraphs/magic-ape/package.json
@@ -18,13 +18,12 @@
     "deploy:studio": "graph deploy --node https://api.studio.thegraph.com/deploy/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.53.0",
-    "@graphprotocol/graph-ts": "^0.27.0"
+    "@graphprotocol/graph-cli": "0.62.0",
+    "@graphprotocol/graph-ts": "^0.31.0"
   },
   "devDependencies": {
-    "matchstick-as": "0.5.0",
+    "matchstick-as": "0.6.0",
     "assemblyscript": "^0.19.20",
-    "wabt": "1.0.24",
     "abi": "workspace:*",
     "misc": "workspace:*"
   }

--- a/subgraphs/magic-glp/package.json
+++ b/subgraphs/magic-glp/package.json
@@ -18,13 +18,12 @@
     "deploy:studio": "graph deploy --node https://api.studio.thegraph.com/deploy/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.53.0",
-    "@graphprotocol/graph-ts": "^0.27.0"
+    "@graphprotocol/graph-cli": "0.62.0",
+    "@graphprotocol/graph-ts": "^0.31.0"
   },
   "devDependencies": {
-    "matchstick-as": "0.5.0",
+    "matchstick-as": "0.6.0",
     "assemblyscript": "^0.19.20",
-    "wabt": "1.0.24",
     "abi": "workspace:*",
     "misc": "workspace:*"
   }

--- a/subgraphs/mspell/package.json
+++ b/subgraphs/mspell/package.json
@@ -18,13 +18,12 @@
     "deploy:studio": "graph deploy --node https://api.studio.thegraph.com/deploy/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.53.0",
-    "@graphprotocol/graph-ts": "^0.27.0"
+    "@graphprotocol/graph-cli": "0.62.0",
+    "@graphprotocol/graph-ts": "^0.31.0"
   },
   "devDependencies": {
-    "matchstick-as": "0.5.0",
+    "matchstick-as": "0.6.0",
     "assemblyscript": "^0.19.20",
-    "wabt": "1.0.24",
     "abi": "workspace:*",
     "misc": "workspace:*"
   }

--- a/subgraphs/spell/package.json
+++ b/subgraphs/spell/package.json
@@ -18,13 +18,12 @@
     "deploy:studio": "graph deploy --node https://api.studio.thegraph.com/deploy/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.53.0",
-    "@graphprotocol/graph-ts": "^0.27.0"
+    "@graphprotocol/graph-cli": "0.62.0",
+    "@graphprotocol/graph-ts": "^0.31.0"
   },
   "devDependencies": {
-    "matchstick-as": "0.5.0",
+    "matchstick-as": "0.6.0",
     "assemblyscript": "^0.19.20",
-    "wabt": "1.0.24",
     "abi": "workspace:*",
     "misc": "workspace:*"
   }

--- a/subgraphs/sspell/package.json
+++ b/subgraphs/sspell/package.json
@@ -18,13 +18,12 @@
     "deploy:studio": "graph deploy --node https://api.studio.thegraph.com/deploy/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.53.0",
-    "@graphprotocol/graph-ts": "^0.27.0"
+    "@graphprotocol/graph-cli": "0.62.0",
+    "@graphprotocol/graph-ts": "^0.31.0"
   },
   "devDependencies": {
-    "matchstick-as": "0.5.0",
+    "matchstick-as": "0.6.0",
     "assemblyscript": "^0.19.20",
-    "wabt": "1.0.24",
     "abi": "workspace:*",
     "misc": "workspace:*"
   }


### PR DESCRIPTION
### Description

Add events to the subgraph. Can be used to e.g. find liquidations in a cauldron. Bumped `graph-cli`, `graph-ts` and `matchstick-as` to use `loadInBlock`.

### Deployments

* **[Ethereum](https://thegraph.com/hosted-service/subgraph/0xmdreamy/abra-liquidations-mainnet)**
* **[Arbitrum](https://thegraph.com/hosted-service/subgraph/0xmdreamy/abra-liquidations-arb)**
* **[Avalanche](https://thegraph.com/hosted-service/subgraph/0xmdreamy/abra-liquidations-avax)**
* **[BSC](https://thegraph.com/hosted-service/subgraph/0xmdreamy/abra-liquidations-bsc)**